### PR TITLE
Fixes issue loading plugin on Kong 1.x

### DIFF
--- a/handler.lua
+++ b/handler.lua
@@ -1,4 +1,3 @@
-local json = require('cjson')
 local BasePlugin = require "kong.plugins.base_plugin"
 local jwt_decoder = require "kong.plugins.jwt.jwt_parser"
 local req_set_header = ngx.req.set_header


### PR DESCRIPTION
Without this loading the plugin on Kon 1.x (not sure about pre 1.x though) gives this error:
```
2019/06/06 10:23:16 [error] 1#0: init_by_lua error: /usr/local/share/lua/5.1/kong/tools/utils.lua:590: ...hare/lua/5.1/kong/plugins/jwt-claims-headers/handler.lua:2: module 'kong.tools.responses' not found:No LuaRocks module found for kong.tools.responses,
```
Removing the line fixed that. It was not used anywhere in the code.